### PR TITLE
fix: Updated assumeRoleDurationSeconds default to 900

### DIFF
--- a/API.md
+++ b/API.md
@@ -57,7 +57,7 @@ public readonly assumeRoleDurationSeconds: number;
 ```
 
 - *Type:* `number`
-- *Default:* 300
+- *Default:* 900
 
 Duration of assume role session.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export class DeployableAwsCdkTypeScriptApp extends awscdk.AwsCdkTypeScriptApp {
 
       const assumeRoleSettings = awsCredentials.roleToAssume ? {
         roleToAssume: awsCredentials.roleToAssume,
-        assumeRoleDurationSeconds: awsCredentials.assumeRoleDurationSeconds || 300,
+        assumeRoleDurationSeconds: awsCredentials.assumeRoleDurationSeconds || 900,
       }: undefined
 
       const accessKeyIdSecretName = awsCredentials.accessKeyIdSecretName ?? 'AWS_ACCESS_KEY_ID'

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface AWSCredentials {
 
   /**
    * Duration of assume role session
-   * @default 300
+   * @default 900
    */
   readonly assumeRoleDurationSeconds?: number;
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -598,7 +598,7 @@ jobs:
             hasPostDeployTask: \\"false\\"
             postDeploymentScript: \\"\\"
             roleToAssume: dev-role
-            assumeRoleDurationSeconds: 300
+            assumeRoleDurationSeconds: 900
         environment:
           - dev
 "


### PR DESCRIPTION
Fixes #
Updated assumeRoleDurationSeconds default to 900 seconds which is the current minimum DurationSeconds that can be set for [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)