### PR TITLE
fix(concurrency): change concurrency in the release workflow to match properties required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,10 @@ export class DeployableAwsCdkTypeScriptApp extends awscdk.AwsCdkTypeScriptApp {
 
     const jobDefinition: Job = {
       runsOn: ['ubuntu-latest'],
-      concurrency: '${{ matrix.environment }}-deploy',
+      concurrency: {
+        'group': '${{ matrix.environment }}-deploy',
+        'cancel-in-progress': false,
+      },
       needs: [
         'release_github',
       ],

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -100,7 +100,9 @@ jobs:
       id-token: write
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -256,7 +258,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -747,7 +751,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -893,7 +899,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1054,7 +1062,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1216,7 +1226,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     env:
       STAGE: \${{ matrix.environment }}
     steps:
@@ -1386,7 +1398,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1552,7 +1566,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1714,7 +1730,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -1876,7 +1894,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -2036,7 +2056,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -2196,7 +2218,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -2351,7 +2375,9 @@ jobs:
       deployments: read
     environment:
       name: \${{ matrix.environment }}
-    concurrency: \${{ matrix.environment }}-deploy
+    concurrency:
+      group: \${{ matrix.environment }}-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Github recently changed the concurrency property from a string to an object with "group" and "cancel-in-progress", this change simply updates the property in the release workflow to match that (and uses cancel-in-progress: false - which for now is a like-for-like substitution of existing behaviour)