### PR TITLE
fix: diff method to use TemplateOnly for improved output handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,13 +26,13 @@ export class DeployableAwsCdkTypeScriptApp extends awscdk.AwsCdkTypeScriptApp {
     const sourceCode = new SourceCode(project, filePath);
     sourceCode.line("import {createWriteStream} from 'fs'");
     sourceCode.line("import {formatDifferences} from '@aws-cdk/cloudformation-diff';");
-    sourceCode.line("import {Toolkit} from '@aws-cdk/toolkit-lib';");
+    sourceCode.line("import {DiffMethod, Toolkit} from '@aws-cdk/toolkit-lib';");
     sourceCode.line('');
     sourceCode.line('const cdk = new Toolkit({});');
     sourceCode.line('');
     sourceCode.open('async function main() {');
     sourceCode.line(`const cx = await cdk.fromCdkApp('ts-node-transpile-only ${path.posix.join(project.srcdir, project.appEntrypoint)}');`);
-    sourceCode.line('const diffs = await cdk.diff(cx, {});');
+    sourceCode.line('const diffs = await cdk.diff(cx, {method: DiffMethod.TemplateOnly()});');
     sourceCode.line("const stream = createWriteStream('./cdk.out/diff.log');");
     sourceCode.open('Object.entries(diffs).forEach(([stackName, diff]) => {');
     sourceCode.line('stream.write(`Difference for stack ${stackName}:\\n`);');

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1549,13 +1549,13 @@ jobs:
 exports[`diff output and annotation When diff output is enabled with annotation Should not generate the diff script 1`] = `
 "import {createWriteStream} from 'fs'
 import {formatDifferences} from '@aws-cdk/cloudformation-diff';
-import {Toolkit} from '@aws-cdk/toolkit-lib';
+import {DiffMethod, Toolkit} from '@aws-cdk/toolkit-lib';
 
 const cdk = new Toolkit({});
 
 async function main() {
   const cx = await cdk.fromCdkApp('ts-node-transpile-only src/main.ts');
-  const diffs = await cdk.diff(cx, {});
+  const diffs = await cdk.diff(cx, {method: DiffMethod.TemplateOnly()});
   const stream = createWriteStream('./cdk.out/diff.log');
   Object.entries(diffs).forEach(([stackName, diff]) => {
     stream.write(\`Difference for stack \${stackName}:\\n\`);


### PR DESCRIPTION
Fixes #. Update the diff method to utilize `TemplateOnly` for better output management. This change enhances the clarity and relevance of the differences generated.
The existing diff method results in the non-existing stacks to go in `Review In Progress` state.

