### PR TITLE
feat(deploy): added option for specifying the runner for deployment jobs

### DIFF
--- a/API.md
+++ b/API.md
@@ -4925,6 +4925,7 @@ const deployOptions: DeployOptions = { ... }
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.jobStrategy">jobStrategy</a></code> | <code><a href="#deployable-awscdk-app-ts.DeployJobStrategy">DeployJobStrategy</a></code> | Deployment job strategy, whether to use a matrix job or multiple jobs for each environment. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.method">method</a></code> | <code>string</code> | How to perform the deployment. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.npmConfigEnvironment">npmConfigEnvironment</a></code> | <code>string</code> | npm config name to set as the environment name This might be useful in deployment process. |
+| <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.runsOn">runsOn</a></code> | <code>string</code> | The type of runner to use for the deployment jobs in the workflow. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.stackPattern">stackPattern</a></code> | <code>string</code> | Regex for stacks to be deployed. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.taskToRunPreInstall">taskToRunPreInstall</a></code> | <code>string</code> | task name to run prior to installation in deploy job of workflow if not provided will not add to workflow. |
 
@@ -4997,6 +4998,19 @@ npm config name to set as the environment name This might be useful in deploymen
 Does not support node versions above 18.
 
 if not provided will not set
+
+---
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="deployable-awscdk-app-ts.DeployOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string;
+```
+
+- *Type:* string
+- *Default:* "ubuntu-latest"
+
+The type of runner to use for the deployment jobs in the workflow.
 
 ---
 
@@ -5315,7 +5329,7 @@ The environment to format the diff for.
 ##### `getJobForEnvironment` <a name="getJobForEnvironment" id="deployable-awscdk-app-ts.DeployableAwsCdkTypeScriptAppStepsFactory.getJobForEnvironment"></a>
 
 ```typescript
-public getJobForEnvironment(environmentOptions: EnvironmentOptions, environmentVariableName?: string): Job
+public getJobForEnvironment(environmentOptions: EnvironmentOptions, environmentVariableName?: string, runsOn?: string): Job
 ```
 
 Get the job definition for a specific environment.
@@ -5333,6 +5347,14 @@ The environment options.
 - *Type:* string
 
 The name of the environment variable to set with the environment name, if any.
+
+---
+
+###### `runsOn`<sup>Optional</sup> <a name="runsOn" id="deployable-awscdk-app-ts.DeployableAwsCdkTypeScriptAppStepsFactory.getJobForEnvironment.parameter.runsOn"></a>
+
+- *Type:* string
+
+The type of runner to use for the deployment job, if any.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -4925,7 +4925,6 @@ const deployOptions: DeployOptions = { ... }
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.jobStrategy">jobStrategy</a></code> | <code><a href="#deployable-awscdk-app-ts.DeployJobStrategy">DeployJobStrategy</a></code> | Deployment job strategy, whether to use a matrix job or multiple jobs for each environment. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.method">method</a></code> | <code>string</code> | How to perform the deployment. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.npmConfigEnvironment">npmConfigEnvironment</a></code> | <code>string</code> | npm config name to set as the environment name This might be useful in deployment process. |
-| <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.runsOn">runsOn</a></code> | <code>string</code> | The type of runner to use for the deployment jobs in the workflow. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.stackPattern">stackPattern</a></code> | <code>string</code> | Regex for stacks to be deployed. |
 | <code><a href="#deployable-awscdk-app-ts.DeployOptions.property.taskToRunPreInstall">taskToRunPreInstall</a></code> | <code>string</code> | task name to run prior to installation in deploy job of workflow if not provided will not add to workflow. |
 
@@ -5001,19 +5000,6 @@ if not provided will not set
 
 ---
 
-##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="deployable-awscdk-app-ts.DeployOptions.property.runsOn"></a>
-
-```typescript
-public readonly runsOn: string;
-```
-
-- *Type:* string
-- *Default:* "ubuntu-latest"
-
-The type of runner to use for the deployment jobs in the workflow.
-
----
-
 ##### `stackPattern`<sup>Optional</sup> <a name="stackPattern" id="deployable-awscdk-app-ts.DeployOptions.property.stackPattern"></a>
 
 ```typescript
@@ -5060,6 +5046,8 @@ const environmentOptions: EnvironmentOptions = { ... }
 | <code><a href="#deployable-awscdk-app-ts.EnvironmentOptions.property.name">name</a></code> | <code>string</code> | Environment name to deploy to. |
 | <code><a href="#deployable-awscdk-app-ts.EnvironmentOptions.property.postDeployWorkflowScript">postDeployWorkflowScript</a></code> | <code>string</code> | The script/task to run after deployment of the environment in the workflow If not present, the workflow will not execute that. |
 | <code><a href="#deployable-awscdk-app-ts.EnvironmentOptions.property.preDeployWorkflowScript">preDeployWorkflowScript</a></code> | <code>string</code> | The script/task to run before deployment of the environment in the workflow If not present, the workflow will not execute that. |
+| <code><a href="#deployable-awscdk-app-ts.EnvironmentOptions.property.runsOn">runsOn</a></code> | <code>string</code> | The type of runner to use for the deployment jobs in the workflow This is not supported in Matrix job strategy and will be ignored if the job strategy is set to Matrix. |
+| <code><a href="#deployable-awscdk-app-ts.EnvironmentOptions.property.runsOnGroup">runsOnGroup</a></code> | <code>projen.GroupRunnerOptions</code> | Github Runner Group selection options This is not supported in Matrix job strategy and will be ignored if the job strategy is set to Matrix. |
 
 ---
 
@@ -5124,6 +5112,31 @@ The script/task to run before deployment of the environment in the workflow If n
 "pre:deploy"
 ```
 
+
+##### `runsOn`<sup>Optional</sup> <a name="runsOn" id="deployable-awscdk-app-ts.EnvironmentOptions.property.runsOn"></a>
+
+```typescript
+public readonly runsOn: string;
+```
+
+- *Type:* string
+- *Default:* "ubuntu-latest"
+
+The type of runner to use for the deployment jobs in the workflow This is not supported in Matrix job strategy and will be ignored if the job strategy is set to Matrix.
+
+---
+
+##### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="deployable-awscdk-app-ts.EnvironmentOptions.property.runsOnGroup"></a>
+
+```typescript
+public readonly runsOnGroup: GroupRunnerOptions;
+```
+
+- *Type:* projen.GroupRunnerOptions
+
+Github Runner Group selection options This is not supported in Matrix job strategy and will be ignored if the job strategy is set to Matrix.
+
+---
 
 ## Classes <a name="Classes" id="Classes"></a>
 
@@ -5289,7 +5302,7 @@ The name of the environment.
 ##### `getDiffAnnotationJobForEnvironment` <a name="getDiffAnnotationJobForEnvironment" id="deployable-awscdk-app-ts.DeployableAwsCdkTypeScriptAppStepsFactory.getDiffAnnotationJobForEnvironment"></a>
 
 ```typescript
-public getDiffAnnotationJobForEnvironment(environmentOptions: EnvironmentOptions, environmentVariableName?: string): Job
+public getDiffAnnotationJobForEnvironment(environmentOptions: EnvironmentOptions, environmentVariableName?: string, runsOn?: string, runsOnGroup?: GroupRunnerOptions): Job
 ```
 
 Get the deployment method argument for the deploy command.
@@ -5307,6 +5320,22 @@ The environment options.
 - *Type:* string
 
 The name of the environment variable to set with the environment name, if any.
+
+---
+
+###### `runsOn`<sup>Optional</sup> <a name="runsOn" id="deployable-awscdk-app-ts.DeployableAwsCdkTypeScriptAppStepsFactory.getDiffAnnotationJobForEnvironment.parameter.runsOn"></a>
+
+- *Type:* string
+
+The type of runner to use for the deployment job, if any.
+
+---
+
+###### `runsOnGroup`<sup>Optional</sup> <a name="runsOnGroup" id="deployable-awscdk-app-ts.DeployableAwsCdkTypeScriptAppStepsFactory.getDiffAnnotationJobForEnvironment.parameter.runsOnGroup"></a>
+
+- *Type:* projen.GroupRunnerOptions
+
+The group of runners to use for the deployment job, if any.
 
 ---
 
@@ -5329,7 +5358,7 @@ The environment to format the diff for.
 ##### `getJobForEnvironment` <a name="getJobForEnvironment" id="deployable-awscdk-app-ts.DeployableAwsCdkTypeScriptAppStepsFactory.getJobForEnvironment"></a>
 
 ```typescript
-public getJobForEnvironment(environmentOptions: EnvironmentOptions, environmentVariableName?: string, runsOn?: string): Job
+public getJobForEnvironment(environmentOptions: EnvironmentOptions, environmentVariableName?: string): Job
 ```
 
 Get the job definition for a specific environment.
@@ -5347,14 +5376,6 @@ The environment options.
 - *Type:* string
 
 The name of the environment variable to set with the environment name, if any.
-
----
-
-###### `runsOn`<sup>Optional</sup> <a name="runsOn" id="deployable-awscdk-app-ts.DeployableAwsCdkTypeScriptAppStepsFactory.getJobForEnvironment.parameter.runsOn"></a>
-
-- *Type:* string
-
-The type of runner to use for the deployment job, if any.
 
 ---
 

--- a/src/steps.ts
+++ b/src/steps.ts
@@ -1,4 +1,4 @@
-import { javascript, github } from 'projen';
+import { javascript, github, GroupRunnerOptions } from 'projen';
 import { WorkflowSteps } from 'projen/lib/github';
 import { JobPermission, JobStep, Job } from 'projen/lib/github/workflows-model';
 import { CodeArtifactAuthProvider } from 'projen/lib/javascript';
@@ -634,13 +634,18 @@ export class DeployableAwsCdkTypeScriptAppStepsFactory {
     environmentOptions: EnvironmentOptions,
     environmentVariableName: string | undefined,
   ): Job {
-    const { name } = environmentOptions;
+    const { name, runsOn, runsOnGroup } = environmentOptions;
     const deployJobEnv = environmentVariableName ? {
       [environmentVariableName]: name,
     } : undefined;
 
+    if (runsOn && runsOnGroup) {
+      throw new Error('Both `runsOn` and `runsOnGroup` cannot be specified simultaneously.');
+    }
+
     const jobDefinition: Job = {
-      runsOn: ['ubuntu-latest'],
+      runsOn: runsOnGroup ? undefined : [runsOn ?? 'ubuntu-latest'],
+      runsOnGroup: runsOnGroup,
       concurrency: {
         'group': `${name}-deploy`,
         'cancel-in-progress': false,
@@ -783,19 +788,28 @@ export class DeployableAwsCdkTypeScriptAppStepsFactory {
    * Get the deployment method argument for the deploy command
    * @param environmentOptions The environment options
    * @param environmentVariableName The name of the environment variable to set with the environment name, if any
+   * @param runsOn The type of runner to use for the deployment job, if any
+   * @param runsOnGroup The group of runners to use for the deployment job, if any
    * @returns The diff annotation job for the environment
    */
   public getDiffAnnotationJobForEnvironment(
     environmentOptions: EnvironmentOptions,
     environmentVariableName: string | undefined,
+    runsOn?: string,
+    runsOnGroup?: GroupRunnerOptions,
   ): Job {
     const { name } = environmentOptions;
     const deployJobEnv = environmentVariableName ? {
       [environmentVariableName]: name,
     } : undefined;
 
+    if (runsOn && runsOnGroup) {
+      throw new Error('Both `runsOn` and `runsOnGroup` cannot be specified simultaneously.');
+    }
+
     const jobDefinition: Job = {
-      runsOn: ['ubuntu-latest'],
+      runsOn: runsOnGroup ? undefined : [runsOn ?? 'ubuntu-latest'],
+      runsOnGroup: runsOnGroup,
       needs: ['build'],
       permissions: {
         contents: JobPermission.READ,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { awscdk } from 'projen';
+import { awscdk, GroupRunnerOptions } from 'projen';
 
 export interface DeployableAwsCdkTypeScriptAppDiffOutputOptions {
   /**
@@ -126,6 +126,21 @@ export interface EnvironmentOptions {
    * @example "pre:deploy"
    */
   readonly preDeployWorkflowScript?: string;
+
+  /**
+   * The type of runner to use for the deployment jobs in the workflow
+   * This is not supported in Matrix job strategy and will be ignored if the job strategy is set to Matrix
+   * @default "ubuntu-latest"
+   */
+  readonly runsOn?: string;
+
+  /**
+   * Github Runner Group selection options
+   * This is not supported in Matrix job strategy and will be ignored if the job strategy is set to Matrix
+   * @description Defines a target Runner Group by name and/or labels
+   * @throws {Error} if both `runsOn` and `runsOnGroup` are specified
+   */
+  readonly runsOnGroup?: GroupRunnerOptions;
 }
 
 export interface AWSCredentials {

--- a/test/steps/__snapshots__/diffAnnotationJobs.test.ts.snap
+++ b/test/steps/__snapshots__/diffAnnotationJobs.test.ts.snap
@@ -55,6 +55,7 @@ exports[`DeployableAwsCdkTypeScriptAppStepsFactory diffAnnotationJobs Should gen
     "runsOn": [
       "ubuntu-latest",
     ],
+    "runsOnGroup": undefined,
     "steps": [
       {
         "continueOnError": undefined,
@@ -167,6 +168,7 @@ echo "" >> diff-output/diff-\${environment}.md",
     "runsOn": [
       "ubuntu-latest",
     ],
+    "runsOnGroup": undefined,
     "steps": [
       {
         "continueOnError": undefined,
@@ -323,6 +325,7 @@ exports[`DeployableAwsCdkTypeScriptAppStepsFactory diffAnnotationJobs Should gen
     "runsOn": [
       "ubuntu-latest",
     ],
+    "runsOnGroup": undefined,
     "steps": [
       {
         "continueOnError": undefined,
@@ -428,6 +431,7 @@ echo "" >> diff-output/diff-\${environment}.md",
     "runsOn": [
       "ubuntu-latest",
     ],
+    "runsOnGroup": undefined,
     "steps": [
       {
         "continueOnError": undefined,

--- a/test/steps/deploymentJobs.test.ts
+++ b/test/steps/deploymentJobs.test.ts
@@ -1,0 +1,53 @@
+import { NodePackageManager } from 'projen/lib/javascript';
+import { DeployableAwsCdkTypeScriptApp, DeployJobStrategy, DeployOptions } from '../../src';
+import { DeployableAwsCdkTypeScriptAppStepsFactory } from '../../src/steps';
+
+describe('getJobForEnvironment', () => {
+  const deployOptions: DeployOptions = {
+    environments: [
+      {
+        name: 'Dev',
+        awsCredentials: {
+          region: 'us-east-1',
+        },
+      },
+      {
+        name: 'UAT',
+        awsCredentials: {
+          region: 'us-east-1',
+        },
+        runsOn: 'stub-runner',
+      },
+    ],
+    environmentVariableName: 'STACK_ENV',
+  };
+  const project = new DeployableAwsCdkTypeScriptApp({
+    name: 'test',
+    defaultReleaseBranch: 'main',
+    cdkVersion: '2.0.0',
+    deployOptions,
+    packageManager: NodePackageManager.PNPM,
+    minNodeVersion: '20.0.0',
+  });
+
+  const factory = new DeployableAwsCdkTypeScriptAppStepsFactory(
+    project,
+    {
+      checkActiveDeployment: false,
+      deployOptions,
+      jobStrategy: DeployJobStrategy.MULTI_JOB,
+    },
+  );
+
+  test('Should return a job definition with the default runsOn value When runsOn is NOT specified', () => {
+    const result = factory.getJobForEnvironment(deployOptions.environments[0], deployOptions.environmentVariableName);
+
+    expect(result.runsOn).toEqual(['ubuntu-latest']);
+  });
+
+  test('Should return a job definition with the correct runsOn value When runsOn is specified', () => {
+    const result = factory.getJobForEnvironment(deployOptions.environments[1], deployOptions.environmentVariableName);
+
+    expect(result.runsOn).toEqual(['stub-runner']);
+  });
+});


### PR DESCRIPTION
Introduce a new option to specify the runner type for deployment jobs, enhancing flexibility in deployment configurations. This update includes validation to prevent simultaneous specification of `runsOn` and `runsOnGroup`.

